### PR TITLE
Refactor HashMap access to use Entry API

### DIFF
--- a/src/aoc-2021-14/src/main.rs
+++ b/src/aoc-2021-14/src/main.rs
@@ -29,14 +29,7 @@ where
     }
 
     pub fn addsert(&mut self, key: T, val: usize) -> usize {
-        if let std::collections::hash_map::Entry::Vacant(e) = self.inner.entry(key) {
-            e.insert(val);
-            val
-        } else {
-            let current_count = self.inner.get_mut(&key).unwrap();
-            *current_count += val;
-            *current_count
-        }
+        *self.inner.entry(key).and_modify(|v| *v += val).or_insert(val)
     }
 }
 
@@ -48,12 +41,7 @@ where
         let mut counter: Counter<U> = Counter::new();
 
         for i in iter {
-            if let std::collections::hash_map::Entry::Vacant(e) = counter.inner.entry(i) {
-                e.insert(1);
-            } else {
-                let current_count = counter.inner.get_mut(&i).unwrap();
-                *current_count += 1;
-            }
+            counter.addsert(i, 1);
         }
         counter
     }


### PR DESCRIPTION
I peeked at your code for today to see what the mathy solution was, but I'll have to get you to explain it to me.  I noticed this, though, and wanted to mention it before I forgot.  `HashMap` has a super neat `Entry` API that makes managing missing values really slick.

https://doc.rust-lang.org/std/collections/hash_map/enum.Entry.html